### PR TITLE
Augusto/banner grid

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -263,16 +263,50 @@ const manifest: DecoManifest = {
         "title": " Bannner Grid",
         "type": "object",
         "properties": {
-          "images": {
+          "title": {
+            "type": [
+              "string",
+              "null",
+            ],
+            "title": "Title",
+          },
+          "itemsPerLine": {
+            "title": "Items Per Line",
+            "type": "object",
+            "properties": {
+              "mobile": {
+                "type": [
+                  "number",
+                  "null",
+                ],
+                "title": "Mobile",
+              },
+              "desktop": {
+                "type": [
+                  "number",
+                  "null",
+                ],
+                "title": "Desktop",
+              },
+            },
+            "required": [],
+            "description": "Default is 2 for mobile and all for desktop",
+          },
+          "banners": {
             "type": "array",
             "items": {
               "title": "Banner",
               "type": "object",
               "properties": {
-                "src": {
+                "srcMobile": {
                   "format": "image-uri",
                   "type": "string",
-                  "title": "Src",
+                  "title": "Src Mobile",
+                },
+                "srcDesktop": {
+                  "format": "image-uri",
+                  "type": "string",
+                  "title": "Src Desktop",
                 },
                 "alt": {
                   "type": "string",
@@ -286,21 +320,17 @@ const manifest: DecoManifest = {
                 },
               },
               "required": [
-                "src",
+                "srcMobile",
                 "alt",
                 "href",
               ],
             },
-            "title": "Images",
-          },
-          "title": {
-            "type": "string",
-            "title": "Title",
+            "title": "Banners",
           },
         },
         "required": [
-          "images",
-          "title",
+          "itemsPerLine",
+          "banners",
         ],
       },
       "outputSchema": null,

--- a/sections/BannnerGrid.tsx
+++ b/sections/BannnerGrid.tsx
@@ -2,7 +2,8 @@ import Image from "$live/std/ui/components/Image.tsx";
 import type { Image as LiveImage } from "$live/std/ui/types/Image.ts";
 
 export interface Banner {
-  src: LiveImage;
+  srcMobile: LiveImage;
+  srcDesktop?: LiveImage;
   /**
    * @description Image alt text
    */
@@ -14,34 +15,61 @@ export interface Banner {
 }
 
 export interface Props {
-  images: Banner[];
-  title: string;
+  title?: string;
+  /**
+   * @description Default is 2 for mobile and all for desktop
+   */
+  itemsPerLine: {
+    mobile?: number;
+    desktop?: number;
+  };
+  banners: Banner[];
 }
 
 export default function BannnerGrid({
-  images = [],
   title,
+  itemsPerLine,
+  banners = [],
 }: Props) {
   return (
     <section class="max-w-[1400px] w-full px-4 md:px-0 mx-auto">
-      <div class="py-6 md:py-0 md:pb-[40px] flex items-center mt-6">
-        <h2 class={"text-lg leading-5 font-semibold uppercase "}>{title}</h2>
+      {title &&
+        (
+          <div class="py-6 md:py-0 md:pb-[40px] flex items-center mt-6">
+            <h2 class={"text-lg leading-5 font-semibold uppercase "}>
+              {title}
+            </h2>
 
-        <div class="bg-[#e5e5ea] h-[1px] w-full ml-4"></div>
-      </div>
-      <div class="grid grid-cols-2 md:grid-cols-3 gap-2 md:gap-4">
-        {images.map(({ href, src, alt }) => (
+            <div class="bg-[#e5e5ea] h-[1px] w-full ml-4"></div>
+          </div>
+        )}
+      <div
+        class={`grid gap-4 md:gap-6 grid-cols-${
+          itemsPerLine && itemsPerLine.mobile ? itemsPerLine.mobile : "2"
+        } md:grid-cols-${
+          itemsPerLine && itemsPerLine.desktop
+            ? itemsPerLine.desktop
+            : banners.length
+        }`}
+      >
+        {banners.map(({ href, srcMobile, srcDesktop, alt }) => (
           <a href={href}>
-            <Image
-              width={320}
-              height={320}
-              src={src}
-              alt={alt}
-              decoding="async"
-              loading="lazy"
-              sizes="(max-width: 640px) 100vw, 30vw"
-              class="w-full"
-            />
+            <picture>
+              <source
+                media="(max-width: 767px)"
+                srcset={srcMobile}
+              />
+              <source
+                media="(min-width: 768px)"
+                srcset={srcDesktop ? srcDesktop : srcMobile}
+              />
+              <Image
+                class="w-full"
+                sizes="(max-width: 640px) 100vw, 30vw"
+                src={srcMobile}
+                alt={alt}
+              />
+            </picture>
           </a>
         ))}
       </div>

--- a/sections/BannnerGrid.tsx
+++ b/sections/BannnerGrid.tsx
@@ -68,6 +68,8 @@ export default function BannnerGrid({
                 sizes="(max-width: 640px) 100vw, 30vw"
                 src={srcMobile}
                 alt={alt}
+                decoding="async"
+                loading="lazy"
               />
             </picture>
           </a>

--- a/sections/Spacer.tsx
+++ b/sections/Spacer.tsx
@@ -1,5 +1,5 @@
 export default function Spacer(
   { height = 8, heightMobile = 8 }: { height?: number; heightMobile?: number },
 ) {
-  return <div class={`h-${heightMobile} h-md-${height}`} />;
+  return <div class={`h-${heightMobile} md:h-${height}`} />;
 }


### PR DESCRIPTION
Improve bannerGrid section
- Allow using different images for desktop and mobile
- Allow distributing all images (desktop) or defining number of images per line (desktop and mobile)
- Reorder props
- Improve style

![screencapture-localhost-8000-2023-02-14-09_31_43](https://user-images.githubusercontent.com/1315451/219375964-7638924f-ea38-45cc-99b2-0c24730b0005.png)
